### PR TITLE
Add parent URLs from page 4 of repositories

### DIFF
--- a/forked_repos.md
+++ b/forked_repos.md
@@ -164,6 +164,7 @@
 | CodeR | 2024-06-29 |  | https://github.com/evelynmitchell/CodeR | https://github.com/NL2Code/CodeR |
 | shap | 2024-06-29 | A game theoretic approach to explain the output of any machine learning model. | https://github.com/evelynmitchell/shap | https://github.com/shap/shap |
 | mirage | 2024-06-27 | A multi-level tensor algebra superoptimizer | https://github.com/evelynmitchell/mirage | https://github.com/mirage-project/mirage |
+| golem | 2024-06-27 | A Framework for Building Robust Shiny Apps  | https://github.com/evelynmitchell/golem | https://github.com/ThinkR-open/golem |
 | ml-4m | 2024-06-26 | 4M: Massively Multimodal Masked Modeling | https://github.com/evelynmitchell/ml-4m | https://github.com/apple/ml-4m |
 | pgai | 2024-06-25 | Bring AI models closer to your PostgreSQL data | https://github.com/evelynmitchell/pgai | https://github.com/timescale/pgai |
 | bug-in-the-code-stack | 2024-06-24 | A new benchmark for measuring LLM's capability to detect bugs in large codebase. | https://github.com/evelynmitchell/bug-in-the-code-stack | https://github.com/HammingHQ/bug-in-the-code-stack |
@@ -199,6 +200,7 @@
 | firecrawl | 2024-05-25 | 🔥 Turn entire websites into LLM-ready markdown or structured data. Scrape, crawl, search and extract with a single API. | https://github.com/evelynmitchell/firecrawl | https://github.com/mendableai/firecrawl |
 | indexify | 2024-05-24 | A scalable realtime and continuous indexing and structured extraction engine for Unstructured Data to build Generative AI Applications | https://github.com/evelynmitchell/indexify | https://github.com/tensorlakeai/indexify |
 | langtrace | 2024-05-23 | Langtrace 🔍 is an open-source,  Open Telemetry based end-to-end observability tool for LLM applications, providing real-time tracing, evaluations and metrics for popular LLMs, LLM frameworks, vectorDBs and more.. Integrate using Typescript, Python. 🚀💻📊 | https://github.com/evelynmitchell/langtrace | https://github.com/Scale3-Labs/langtrace |
+| ml-ogen | 2024-05-20 |  | https://github.com/evelynmitchell/ml-ogen | https://github.com/apple/ml-ogen |
 | openfold | 2024-05-13 | Trainable, memory-efficient, and GPU-friendly PyTorch reproduction of AlphaFold 2 | https://github.com/evelynmitchell/openfold | https://github.com/aqlaboratory/openfold |
 | ThunderKittens | 2024-05-13 | Tile primitives for speedy kernels | https://github.com/evelynmitchell/ThunderKittens | https://github.com/HazyResearch/ThunderKittens |
 | timesfm | 2024-05-11 | TimesFM (Time Series Foundation Model) is a pretrained time-series foundation model developed by Google Research for time-series forecasting. | https://github.com/evelynmitchell/timesfm | https://github.com/google-research/timesfm |
@@ -206,9 +208,26 @@
 | efficient-kan | 2024-05-08 | An efficient pure-PyTorch implementation of Kolmogorov-Arnold Network (KAN). | https://github.com/evelynmitchell/efficient-kan | https://github.com/Blealtan/efficient-kan |
 | Sequoia | 2024-05-05 | scalable and robust tree-based speculative decoding algorithm | https://github.com/evelynmitchell/Sequoia | https://github.com/Infini-AI-Lab/Sequoia |
 | kanrl | 2024-05-04 | Kolmogorov-Arnold Network for Reinforcement Leaning, initial experiments | https://github.com/evelynmitchell/kanrl | https://github.com/riiswa/kanrl |
+| GPT-Fathom | 2024-04-23 | [NAACL'24 Findings] GPT-Fathom is an open-source and reproducible LLM evaluation suite, benchmarking 10+ leading open-source and closed-source LLMs as well as OpenAI's earlier models on 20+ curated benchmarks under aligned settings. | https://github.com/evelynmitchell/GPT-Fathom | https://github.com/GPT-Fathom/GPT-Fathom |
+| codellama | 2024-04-21 | Inference code for CodeLlama models | https://github.com/evelynmitchell/codellama | https://github.com/meta-llama/codellama |
+| recurrentgemma | 2024-04-13 | Open weights language model from Google DeepMind, based on Griffin. | https://github.com/evelynmitchell/recurrentgemma | https://github.com/google-deepmind/recurrentgemma |
+| open-eqa | 2024-04-13 | OpenEQA Embodied Question Answering in the Era of Foundation Models | https://github.com/evelynmitchell/open-eqa | https://github.com/facebookresearch/open-eqa |
+| open-gpu-kernel-modules | 2024-04-13 | NVIDIA Linux open GPU with P2P support | https://github.com/evelynmitchell/open-gpu-kernel-modules | https://github.com/tinygrad/open-gpu-kernel-modules |
+| survey | 2024-04-11 | A golang library for building interactive and accessible prompts with full support for windows and posix terminals. | https://github.com/evelynmitchell/survey | https://github.com/plandex-ai/survey |
+| plandex | 2024-04-11 | An AI coding engine for complex tasks | https://github.com/evelynmitchell/plandex | https://github.com/plandex-ai/plandex |
 | shouldersOfGiants.rs | 2024-04-08 | I have no idea what I'm doing , but llm.c in rust | https://github.com/evelynmitchell/shouldersOfGiants.rs |  |
+| clevergpt | 2024-04-08 | Training GPTs to solve interaction nets | https://github.com/evelynmitchell/clevergpt | https://github.com/reissbaker/clevergpt |
+| dbrx | 2024-04-08 | Code examples and resources for DBRX, a large language model developed by Databricks | https://github.com/evelynmitchell/dbrx | https://github.com/databricks/dbrx |
 | ragflow | 2024-04-05 | RAGFlow is an open-source RAG (Retrieval-Augmented Generation) engine based on deep document understanding. | https://github.com/evelynmitchell/ragflow | https://github.com/infiniflow/ragflow |
+| partykit | 2024-04-05 | PartyKit simplifies developing multiplayer applications | https://github.com/evelynmitchell/partykit | https://github.com/partykit/partykit |
+| magic-spell | 2024-04-05 | 🪄 AI prompting built into your <textarea> | https://github.com/evelynmitchell/magic-spell | https://github.com/ai-ng/magic-spell |
+| devika | 2024-04-04 | Devika is an Agentic AI Software Engineer that can understand high-level human instructions, break them down into steps, research relevant information, and write code to achieve the given objective. Devika aims to be a competitive open-source alternative to Devin by Cognition AI. | https://github.com/evelynmitchell/devika | https://github.com/stitionai/devika |
+| serving | 2024-04-01 | Kubernetes-based, scale-to-zero, request-driven compute | https://github.com/evelynmitchell/serving | https://github.com/knative/serving |
+| OLMo | 2024-04-01 | Modeling, training, eval, and inference code for OLMo | https://github.com/evelynmitchell/OLMo | https://github.com/allenai/OLMo |
 | nvidia-container-toolkit | 2024-04-01 | Build and run containers leveraging NVIDIA GPUs | https://github.com/evelynmitchell/nvidia-container-toolkit | https://github.com/NVIDIA/nvidia-container-toolkit |
+| MiniGemini | 2024-04-01 | Official implementation for Mini-Gemini | https://github.com/evelynmitchell/MiniGemini | https://github.com/dvlab-research/MGM |
+| lightning-thunder | 2024-03-29 | Make PyTorch models Lightning fast! Thunder is a source to source compiler for PyTorch. It enables using different hardware executors at once. | https://github.com/evelynmitchell/lightning-thunder | https://github.com/Lightning-AI/lightning-thunder |
+| AIOS | 2024-03-27 | AIOS: LLM Agent Operating System | https://github.com/evelynmitchell/AIOS | https://github.com/agiresearch/AIOS |
 | chronos-forecasting | 2024-03-25 | Chronos: Pretrained (Language) Models for Probabilistic Time Series Forecasting | https://github.com/evelynmitchell/chronos-forecasting | https://github.com/amazon-science/chronos-forecasting |
 | ib_async | 2024-03-19 | Python sync/async framework for Interactive Brokers API (replaces ib_insync) | https://github.com/evelynmitchell/ib_async | https://github.com/ib-api-reloaded/ib_async |
 | aici | 2024-03-11 | AICI: Prompts as (Wasm) Programs | https://github.com/evelynmitchell/aici | https://github.com/microsoft/aici |
@@ -217,6 +236,7 @@
 | tsmixer | 2024-02-11 | Time Series Mixer forecasting multivariate time series | https://github.com/evelynmitchell/tsmixer |  |
 | AQLM | 2024-02-08 | Official Pytorch repository for Extreme Compression of Large Language Models via Additive Quantization https://arxiv.org/pdf/2401.06118.pdf | https://github.com/evelynmitchell/AQLM | https://github.com/Vahe1994/AQLM |
 | cleanrl | 2024-02-04 | High-quality single file implementation of Deep Reinforcement Learning algorithms with research-friendly features (PPO, DQN, C51, DDPG, TD3, SAC, PPG) | https://github.com/evelynmitchell/cleanrl | https://github.com/vwxyzjn/cleanrl |
+| tsfm | 2024-02-03 | Foundation Models for Time Series | https://github.com/evelynmitchell/tsfm | https://github.com/ibm-granite/granite-tsfm |
 | TinyTimeMixers | 2024-02-02 | Tiny Time Mixers - a time series model 2401.03955 | https://github.com/evelynmitchell/TinyTimeMixers |  |
 | open-instruct | 2024-02-02 |  | https://github.com/evelynmitchell/open-instruct | https://github.com/allenai/open-instruct |
 | MyWay | 2024-01-19 |  | https://github.com/evelynmitchell/MyWay |  |

--- a/repos.json
+++ b/repos.json
@@ -1458,6 +1458,15 @@
     "repositoryTopics": null
   },
   {
+    "name": "golem",
+    "createdAt": "2024-06-27T02:40:28Z",
+    "description": "A Framework for Building Robust Shiny Apps ",
+    "url": "https://github.com/evelynmitchell/golem",
+    "parent_url": "https://github.com/ThinkR-open/golem",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
     "name": "ml-4m",
     "createdAt": "2024-06-26T14:10:18Z",
     "description": "4M: Massively Multimodal Masked Modeling",
@@ -1773,6 +1782,15 @@
     "repositoryTopics": null
   },
   {
+    "name": "ml-ogen",
+    "createdAt": "2024-05-20T00:12:18Z",
+    "description": "",
+    "url": "https://github.com/evelynmitchell/ml-ogen",
+    "parent_url": "https://github.com/apple/ml-ogen",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
     "name": "openfold",
     "createdAt": "2024-05-13T01:54:51Z",
     "description": "Trainable, memory-efficient, and GPU-friendly PyTorch reproduction of AlphaFold 2",
@@ -1836,11 +1854,92 @@
     "repositoryTopics": null
   },
   {
+    "name": "GPT-Fathom",
+    "createdAt": "2024-04-23T00:50:54Z",
+    "description": "[NAACL'24 Findings] GPT-Fathom is an open-source and reproducible LLM evaluation suite, benchmarking 10+ leading open-source and closed-source LLMs as well as OpenAI's earlier models on 20+ curated benchmarks under aligned settings.",
+    "url": "https://github.com/evelynmitchell/GPT-Fathom",
+    "parent_url": "https://github.com/GPT-Fathom/GPT-Fathom",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "codellama",
+    "createdAt": "2024-04-21T01:52:46Z",
+    "description": "Inference code for CodeLlama models",
+    "url": "https://github.com/evelynmitchell/codellama",
+    "parent_url": "https://github.com/meta-llama/codellama",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "recurrentgemma",
+    "createdAt": "2024-04-13T02:09:21Z",
+    "description": "Open weights language model from Google DeepMind, based on Griffin.",
+    "url": "https://github.com/evelynmitchell/recurrentgemma",
+    "parent_url": "https://github.com/google-deepmind/recurrentgemma",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "open-eqa",
+    "createdAt": "2024-04-13T01:44:20Z",
+    "description": "OpenEQA Embodied Question Answering in the Era of Foundation Models",
+    "url": "https://github.com/evelynmitchell/open-eqa",
+    "parent_url": "https://github.com/facebookresearch/open-eqa",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "open-gpu-kernel-modules",
+    "createdAt": "2024-04-13T01:38:40Z",
+    "description": "NVIDIA Linux open GPU with P2P support",
+    "url": "https://github.com/evelynmitchell/open-gpu-kernel-modules",
+    "parent_url": "https://github.com/tinygrad/open-gpu-kernel-modules",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "survey",
+    "createdAt": "2024-04-11T13:41:23Z",
+    "description": "A golang library for building interactive and accessible prompts with full support for windows and posix terminals.",
+    "url": "https://github.com/evelynmitchell/survey",
+    "parent_url": "https://github.com/plandex-ai/survey",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "plandex",
+    "createdAt": "2024-04-11T13:40:09Z",
+    "description": "An AI coding engine for complex tasks",
+    "url": "https://github.com/evelynmitchell/plandex",
+    "parent_url": "https://github.com/plandex-ai/plandex",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
     "name": "shouldersOfGiants.rs",
     "createdAt": "2024-04-08T22:39:32Z",
     "description": "I have no idea what I'm doing , but llm.c in rust",
     "url": "https://github.com/evelynmitchell/shouldersOfGiants.rs",
     "parent_url": null,
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "clevergpt",
+    "createdAt": "2024-04-08T16:39:19Z",
+    "description": "Training GPTs to solve interaction nets",
+    "url": "https://github.com/evelynmitchell/clevergpt",
+    "parent_url": "https://github.com/reissbaker/clevergpt",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "dbrx",
+    "createdAt": "2024-04-08T14:46:02Z",
+    "description": "Code examples and resources for DBRX, a large language model developed by Databricks",
+    "url": "https://github.com/evelynmitchell/dbrx",
+    "parent_url": "https://github.com/databricks/dbrx",
     "labels": [],
     "repositoryTopics": null
   },
@@ -1854,11 +1953,83 @@
     "repositoryTopics": null
   },
   {
+    "name": "partykit",
+    "createdAt": "2024-04-05T16:30:00Z",
+    "description": "PartyKit simplifies developing multiplayer applications",
+    "url": "https://github.com/evelynmitchell/partykit",
+    "parent_url": "https://github.com/partykit/partykit",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "magic-spell",
+    "createdAt": "2024-04-05T01:54:03Z",
+    "description": "\ud83e\ude84 AI prompting built into your <textarea>",
+    "url": "https://github.com/evelynmitchell/magic-spell",
+    "parent_url": "https://github.com/ai-ng/magic-spell",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "devika",
+    "createdAt": "2024-04-04T18:03:05Z",
+    "description": "Devika is an Agentic AI Software Engineer that can understand high-level human instructions, break them down into steps, research relevant information, and write code to achieve the given objective. Devika aims to be a competitive open-source alternative to Devin by Cognition AI.",
+    "url": "https://github.com/evelynmitchell/devika",
+    "parent_url": "https://github.com/stitionai/devika",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "serving",
+    "createdAt": "2024-04-01T22:44:39Z",
+    "description": "Kubernetes-based, scale-to-zero, request-driven compute",
+    "url": "https://github.com/evelynmitchell/serving",
+    "parent_url": "https://github.com/knative/serving",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "OLMo",
+    "createdAt": "2024-04-01T22:00:24Z",
+    "description": "Modeling, training, eval, and inference code for OLMo",
+    "url": "https://github.com/evelynmitchell/OLMo",
+    "parent_url": "https://github.com/allenai/OLMo",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
     "name": "nvidia-container-toolkit",
     "createdAt": "2024-04-01T19:43:19Z",
     "description": "Build and run containers leveraging NVIDIA GPUs",
     "url": "https://github.com/evelynmitchell/nvidia-container-toolkit",
     "parent_url": "https://github.com/NVIDIA/nvidia-container-toolkit",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "MiniGemini",
+    "createdAt": "2024-04-01T02:40:53Z",
+    "description": "Official implementation for Mini-Gemini",
+    "url": "https://github.com/evelynmitchell/MiniGemini",
+    "parent_url": "https://github.com/dvlab-research/MGM",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "lightning-thunder",
+    "createdAt": "2024-03-29T00:27:10Z",
+    "description": "Make PyTorch models Lightning fast! Thunder is a source to source compiler for PyTorch. It enables using different hardware executors at once.",
+    "url": "https://github.com/evelynmitchell/lightning-thunder",
+    "parent_url": "https://github.com/Lightning-AI/lightning-thunder",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "AIOS",
+    "createdAt": "2024-03-27T21:08:18Z",
+    "description": "AIOS: LLM Agent Operating System",
+    "url": "https://github.com/evelynmitchell/AIOS",
+    "parent_url": "https://github.com/agiresearch/AIOS",
     "labels": [],
     "repositoryTopics": null
   },
@@ -1931,6 +2102,15 @@
     "description": "High-quality single file implementation of Deep Reinforcement Learning algorithms with research-friendly features (PPO, DQN, C51, DDPG, TD3, SAC, PPG)",
     "url": "https://github.com/evelynmitchell/cleanrl",
     "parent_url": "https://github.com/vwxyzjn/cleanrl",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "tsfm",
+    "createdAt": "2024-02-03T18:44:52Z",
+    "description": "Foundation Models for Time Series",
+    "url": "https://github.com/evelynmitchell/tsfm",
+    "parent_url": "https://github.com/ibm-granite/granite-tsfm",
     "labels": [],
     "repositoryTopics": null
   },


### PR DESCRIPTION
This PR adds parent URLs for 20 more repositories from page 4.

Changes:
- Added parent URLs for repositories from page 4
- Updated both repos.json and forked_repos.md
- All repositories remain sorted by creation date (newest first)

Progress:
- Total repositories from 2024: 604
- Processed so far: 240 (220 from previous PRs + 20 from this PR)