### PR TITLE
Add parent URLs for fourth batch of repositories

### DIFF
--- a/forked_repos.md
+++ b/forked_repos.md
@@ -272,7 +272,27 @@
 | Sequoia | 2024-05-05 | scalable and robust tree-based speculative decoding algorithm | https://github.com/evelynmitchell/Sequoia | https://github.com/Infini-AI-Lab/Sequoia |
 | kanrl | 2024-05-04 | Kolmogorov-Arnold Network for Reinforcement Leaning, initial experiments | https://github.com/evelynmitchell/kanrl | https://github.com/riiswa/kanrl |
 | cuda-convnet | 2024-05-03 | Alex Krizhevsky's original code from Google Code | https://github.com/evelynmitchell/cuda-convnet | https://github.com/ulrichstern/cuda-convnet |
+| cuda-convnet | 2024-05-03 | Alex Krizhevsky's original code from Google Code | https://github.com/evelynmitchell/cuda-convnet | https://github.com/ulrichstern/cuda-convnet |
+| NeMo-Aligner | 2024-05-03 | Scalable toolkit for efficient model alignment | https://github.com/evelynmitchell/NeMo-Aligner | https://github.com/NVIDIA/NeMo-Aligner |
+| reka-vibe-eval | 2024-05-03 | Multimodal language model benchmark, featuring challenging examples | https://github.com/evelynmitchell/reka-vibe-eval | https://github.com/reka-ai/reka-vibe-eval |
+| outlines | 2024-05-02 | Structured Text Generation | https://github.com/evelynmitchell/outlines | https://github.com/dottxt-ai/outlines |
+| lxmert | 2024-05-02 | PyTorch code for EMNLP 2019 paper "LXMERT: Learning Cross-Modality Encoder Representations from Transformers". | https://github.com/evelynmitchell/lxmert | https://github.com/airsplay/lxmert |
+| torchtitan | 2024-05-01 | A native PyTorch Library for large model training | https://github.com/evelynmitchell/torchtitan | https://github.com/pytorch/torchtitan |
+| pykan | 2024-05-01 | Kolmogorov Arnold Networks | https://github.com/evelynmitchell/pykan | https://github.com/KindXiaoming/pykan |
+| Garment-Pattern-Generator | 2024-04-30 | Official implementation of Generating Datasets of 3D Garments with Sewing Patterns | https://github.com/evelynmitchell/Garment-Pattern-Generator | https://github.com/maria-korosteleva/Garment-Pattern-Generator |
+| loraplus | 2024-04-30 |  | https://github.com/evelynmitchell/loraplus | https://github.com/nikhil-ghosh-berkeley/loraplus |
+| cuda-checkpoint | 2024-04-29 | CUDA checkpoint and restore utility | https://github.com/evelynmitchell/cuda-checkpoint | https://github.com/NVIDIA/cuda-checkpoint |
+| openCypher | 2024-04-28 | Specification of the Cypher property graph query language | https://github.com/evelynmitchell/openCypher | https://github.com/opencypher/openCypher |
+| foyle | 2024-04-26 | AI For Software Operations | https://github.com/evelynmitchell/foyle | https://github.com/jlewi/foyle |
+| opentofu | 2024-04-26 | OpenTofu lets you declaratively manage your cloud infrastructure. | https://github.com/evelynmitchell/opentofu | https://github.com/opentofu/opentofu |
+| llm-transparency-tool | 2024-04-25 | LLM Transparency Tool (LLM-TT), an open-source interactive toolkit for analyzing internal workings of Transformer-based language models. *Check out demo at* https://huggingface.co/spaces/facebook/llm-transparency-tool-demo | https://github.com/evelynmitchell/llm-transparency-tool | https://github.com/facebookresearch/llm-transparency-tool |
+| insanely-fast-whisper | 2024-04-25 |  | https://github.com/evelynmitchell/insanely-fast-whisper | https://github.com/Vaibhavs10/insanely-fast-whisper |
+| jat | 2024-04-24 | Distributed online training of a general multi-task Deep RL Agent | https://github.com/evelynmitchell/jat | https://github.com/huggingface/jat |
+| corenet | 2024-04-24 | CoreNet: A library for training deep neural networks | https://github.com/evelynmitchell/corenet | https://github.com/apple/corenet |
 | GPT-Fathom | 2024-04-23 | [NAACL'24 Findings] GPT-Fathom is an open-source and reproducible LLM evaluation suite, benchmarking 10+ leading open-source and closed-source LLMs as well as OpenAI's earlier models on 20+ curated benchmarks under aligned settings. | https://github.com/evelynmitchell/GPT-Fathom | https://github.com/GPT-Fathom/GPT-Fathom |
+| GPT-Fathom | 2024-04-23 | [NAACL'24 Findings] GPT-Fathom is an open-source and reproducible LLM evaluation suite, benchmarking 10+ leading open-source and closed-source LLMs as well as OpenAI's earlier models on 20+ curated benchmarks under aligned settings. | https://github.com/evelynmitchell/GPT-Fathom | https://github.com/GPT-Fathom/GPT-Fathom |
+| Groma | 2024-04-22 | Official Implementation of "Groma: Localized Visual Tokenization for Grounding Multimodal Large Language Models" | https://github.com/evelynmitchell/Groma | https://github.com/FoundationVision/Groma |
+| modelbench | 2024-04-21 | Run safety benchmarks against AI models and view detailed reports showing how well they performed. | https://github.com/evelynmitchell/modelbench | https://github.com/mlcommons/modelbench |
 | codellama | 2024-04-21 | Inference code for CodeLlama models | https://github.com/evelynmitchell/codellama | https://github.com/meta-llama/codellama |
 | llamafile-convert_gguf_UI | 2024-04-19 | This GUI aims to simplify the process of converting GGUF files to llamafile format by providing an intuitive and convenient way for users to interact with the underlying conversion script. | https://github.com/evelynmitchell/llamafile-convert_gguf_UI | https://github.com/DjagbleyEmmanuel/llamafile-convert_gguf_UI |
 | recurrentgemma | 2024-04-13 | Open weights language model from Google DeepMind, based on Griffin. | https://github.com/evelynmitchell/recurrentgemma | https://github.com/google-deepmind/recurrentgemma |

--- a/repos.json
+++ b/repos.json
@@ -2430,11 +2430,191 @@
     "repositoryTopics": null
   },
   {
+    "name": "cuda-convnet",
+    "createdAt": "2024-05-03T23:41:46Z",
+    "description": "Alex Krizhevsky's original code from Google Code",
+    "url": "https://github.com/evelynmitchell/cuda-convnet",
+    "parent_url": "https://github.com/ulrichstern/cuda-convnet",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "NeMo-Aligner",
+    "createdAt": "2024-05-03T20:07:21Z",
+    "description": "Scalable toolkit for efficient model alignment",
+    "url": "https://github.com/evelynmitchell/NeMo-Aligner",
+    "parent_url": "https://github.com/NVIDIA/NeMo-Aligner",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "reka-vibe-eval",
+    "createdAt": "2024-05-03T02:12:50Z",
+    "description": "Multimodal language model benchmark, featuring challenging examples",
+    "url": "https://github.com/evelynmitchell/reka-vibe-eval",
+    "parent_url": "https://github.com/reka-ai/reka-vibe-eval",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "outlines",
+    "createdAt": "2024-05-02T19:20:31Z",
+    "description": "Structured Text Generation",
+    "url": "https://github.com/evelynmitchell/outlines",
+    "parent_url": "https://github.com/dottxt-ai/outlines",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "lxmert",
+    "createdAt": "2024-05-02T15:03:49Z",
+    "description": "PyTorch code for EMNLP 2019 paper \"LXMERT: Learning Cross-Modality Encoder Representations from Transformers\".",
+    "url": "https://github.com/evelynmitchell/lxmert",
+    "parent_url": "https://github.com/airsplay/lxmert",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "torchtitan",
+    "createdAt": "2024-05-01T15:52:17Z",
+    "description": "A native PyTorch Library for large model training",
+    "url": "https://github.com/evelynmitchell/torchtitan",
+    "parent_url": "https://github.com/pytorch/torchtitan",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "pykan",
+    "createdAt": "2024-05-01T14:04:00Z",
+    "description": "Kolmogorov Arnold Networks",
+    "url": "https://github.com/evelynmitchell/pykan",
+    "parent_url": "https://github.com/KindXiaoming/pykan",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "Garment-Pattern-Generator",
+    "createdAt": "2024-04-30T15:49:38Z",
+    "description": "Official implementation of Generating Datasets of 3D Garments with Sewing Patterns",
+    "url": "https://github.com/evelynmitchell/Garment-Pattern-Generator",
+    "parent_url": "https://github.com/maria-korosteleva/Garment-Pattern-Generator",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "loraplus",
+    "createdAt": "2024-04-30T00:30:28Z",
+    "description": "",
+    "url": "https://github.com/evelynmitchell/loraplus",
+    "parent_url": "https://github.com/nikhil-ghosh-berkeley/loraplus",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "cuda-checkpoint",
+    "createdAt": "2024-04-29T23:40:47Z",
+    "description": "CUDA checkpoint and restore utility",
+    "url": "https://github.com/evelynmitchell/cuda-checkpoint",
+    "parent_url": "https://github.com/NVIDIA/cuda-checkpoint",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "openCypher",
+    "createdAt": "2024-04-28T13:45:33Z",
+    "description": "Specification of the Cypher property graph query language",
+    "url": "https://github.com/evelynmitchell/openCypher",
+    "parent_url": "https://github.com/opencypher/openCypher",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "foyle",
+    "createdAt": "2024-04-26T17:23:15Z",
+    "description": "AI For Software Operations",
+    "url": "https://github.com/evelynmitchell/foyle",
+    "parent_url": "https://github.com/jlewi/foyle",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "opentofu",
+    "createdAt": "2024-04-26T14:27:03Z",
+    "description": "OpenTofu lets you declaratively manage your cloud infrastructure.",
+    "url": "https://github.com/evelynmitchell/opentofu",
+    "parent_url": "https://github.com/opentofu/opentofu",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "llm-transparency-tool",
+    "createdAt": "2024-04-25T19:49:17Z",
+    "description": "LLM Transparency Tool (LLM-TT), an open-source interactive toolkit for analyzing internal workings of Transformer-based language models. *Check out demo at* https://huggingface.co/spaces/facebook/llm-transparency-tool-demo",
+    "url": "https://github.com/evelynmitchell/llm-transparency-tool",
+    "parent_url": "https://github.com/facebookresearch/llm-transparency-tool",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "insanely-fast-whisper",
+    "createdAt": "2024-04-25T19:41:12Z",
+    "description": "",
+    "url": "https://github.com/evelynmitchell/insanely-fast-whisper",
+    "parent_url": "https://github.com/Vaibhavs10/insanely-fast-whisper",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "jat",
+    "createdAt": "2024-04-24T22:10:54Z",
+    "description": "Distributed online training of a general multi-task Deep RL Agent",
+    "url": "https://github.com/evelynmitchell/jat",
+    "parent_url": "https://github.com/huggingface/jat",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "corenet",
+    "createdAt": "2024-04-24T14:00:09Z",
+    "description": "CoreNet: A library for training deep neural networks",
+    "url": "https://github.com/evelynmitchell/corenet",
+    "parent_url": "https://github.com/apple/corenet",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
     "name": "GPT-Fathom",
     "createdAt": "2024-04-23T00:50:54Z",
     "description": "[NAACL'24 Findings] GPT-Fathom is an open-source and reproducible LLM evaluation suite, benchmarking 10+ leading open-source and closed-source LLMs as well as OpenAI's earlier models on 20+ curated benchmarks under aligned settings.",
     "url": "https://github.com/evelynmitchell/GPT-Fathom",
     "parent_url": "https://github.com/GPT-Fathom/GPT-Fathom",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "GPT-Fathom",
+    "createdAt": "2024-04-23T00:50:54Z",
+    "description": "[NAACL'24 Findings] GPT-Fathom is an open-source and reproducible LLM evaluation suite, benchmarking 10+ leading open-source and closed-source LLMs as well as OpenAI's earlier models on 20+ curated benchmarks under aligned settings.",
+    "url": "https://github.com/evelynmitchell/GPT-Fathom",
+    "parent_url": "https://github.com/GPT-Fathom/GPT-Fathom",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "Groma",
+    "createdAt": "2024-04-22T14:42:33Z",
+    "description": "Official Implementation of \"Groma: Localized Visual Tokenization for Grounding Multimodal Large Language Models\"",
+    "url": "https://github.com/evelynmitchell/Groma",
+    "parent_url": "https://github.com/FoundationVision/Groma",
+    "labels": [],
+    "repositoryTopics": null
+  },
+  {
+    "name": "modelbench",
+    "createdAt": "2024-04-21T14:26:21Z",
+    "description": "Run safety benchmarks against AI models and view detailed reports showing how well they performed.",
+    "url": "https://github.com/evelynmitchell/modelbench",
+    "parent_url": "https://github.com/mlcommons/modelbench",
     "labels": [],
     "repositoryTopics": null
   },


### PR DESCRIPTION
This PR adds parent URLs for the fourth batch of 20 repositories processed with the new script.

Changes:
- Updated repos.json with parent URLs for 20 more repositories
- Updated forked_repos.md with the same information
- All repositories remain sorted by creation date (newest first)

Progress:
- Total repositories from 2024: 1329
- Previously processed: 60
- Processed in this batch: 20
- Total processed so far: 80

Next steps:
- After this PR is merged, we can continue processing the next batch of repositories